### PR TITLE
add: チーム参加機能

### DIFF
--- a/app/controllers/teams/attendances_controller.rb
+++ b/app/controllers/teams/attendances_controller.rb
@@ -1,0 +1,13 @@
+class Teams::AttendancesController < ApplicationController
+  def create
+    @team =Team.find(params[:team_id])
+    team_attendance = current_user.attend(@team)
+    redirect_back(fallback_location: root_path, success: '参加の申込をしました')
+  end
+
+  def destroy
+    @team = Team.find(params[:team_id])
+    current_user.cancel_attend(@team)
+    redirect_back(fallback_location: root_path, success: '参加をキャンセルしました')
+  end
+end

--- a/app/decorators/teams/attendance_decorator.rb
+++ b/app/decorators/teams/attendance_decorator.rb
@@ -1,0 +1,13 @@
+class Teams::AttendanceDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/helpers/teams/attendances_helper.rb
+++ b/app/helpers/teams/attendances_helper.rb
@@ -1,0 +1,2 @@
+module Teams::AttendancesHelper
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,11 +12,13 @@ class Team < ApplicationRecord
   validate :valid_term
 
   belongs_to :user
+  has_many :team_attendances, dependent: :destroy
+  has_many :attendees, through: :team_attendances, class_name: 'User', source: :user
 
   enum status: { wanted: 0, full: 1, finished: 2 }
 
   def full?
-    team_attendances.count >= capacity
+    attendees.count >= capacity
   end
 
   def deadline?

--- a/app/models/team_attendance.rb
+++ b/app/models/team_attendance.rb
@@ -1,0 +1,6 @@
+class TeamAttendance < ApplicationRecord
+  belongs_to :team
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :team_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   validates :description, length: { maximum: 655 }
   
   has_many :teams, dependent: :destroy
+  has_many :team_attendances, dependent: :destroy
+  has_many :attend_teams, through: :team_attendances, class_name: 'Team', source: :team
   
   class << self
     def find_or_create_from_auth_hash(auth_hash)
@@ -29,4 +31,16 @@ class User < ApplicationRecord
   def owner?(team)
     team.user_id == id
   end 
+
+  def attend(team)
+    team_attendances.find_or_create_by(team_id: team.id)
+  end
+
+  def attend?(team)
+    attend_teams.include?(team)
+  end
+
+  def cancel_attend(team)
+    attend_teams.destroy(team)
+  end
 end

--- a/app/views/teams/_attendee.html.erb
+++ b/app/views/teams/_attendee.html.erb
@@ -1,0 +1,6 @@
+<li>
+  <div class="d-flex align-items-center gap-2 mb-3">
+    <%= image_tag image_path(attendee.avatar.url), size: '200x200', class: 'w-24 rounded-full' %>
+    <%= link_to attendee.name, user_path(attendee.id) %>
+  </div>
+</li>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,5 +1,5 @@
-<div class="pl-12 flex justify-start items-center min-h-screen bg-gray-100">
-  <div class="card w-200 bg-base-100 shadow-xl image-full">
+<div class="pl-12 flex justify-center items-center min-h-screen bg-gray-100">
+  <div class="card w-100 bg-teal-300 shadow-xl image-full">
     <div class="card-body">
       <figure>
         <%= image_tag @team.thumbnail.url =%>  
@@ -30,11 +30,43 @@
           <%= @team.description %>
         </p>
       </div>
+      <div class="card-actions justify-end">
+        <% if logged_in? %>
+          <% if !current_user.owner?(@team) %>
+            <% if current_user.attend?(@team) %>
+              <%= button_to 'キャンセルする',
+                          team_attendance_url(@team),
+                           class: 'btn btn-primary',
+                           method: :delete,
+                           data: { confirm: 'キャンセルする' } %>
+            <% else %>
+              <%= button_to 'このチームに参加する',
+                          team_attendance_url(@team),
+                          class: 'btn btn-accent',
+                          method: :post,
+                          data: { confirm: '参加する' } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
       <% if current_user.owner?(@team) %>
         <div class="card-actions justify-end">
-          <%= button_to t('defaults.edit'), edit_team_path(@team), method: :get, class: 'btn btn-primary' %>
+          <%= button_to t('defaults.edit'), edit_team_path(@team), method: :get, class: 'btn btn-accent' %>
+          <%= button_to t('defaults.destroy'), teams_path, method: :delete, class: 'btn btn-primary' %>
         </div>
       <% end %>
+    </div>
+  </div>
+  <div class="card w-96 bg-primary text-primary-content">
+    <div class="card-body">
+      <h2 class="card-title">参加者</h2>
+      <ul class="list-unstyled">
+        <% if @team.attendees.present? %>
+          <%= render partial: 'teams/attendee', collection: @team.attendees %>
+        <% else %>
+          <li>まだ参加者はいません</li>
+        <% end %>
+      </ul>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     register: 'これでよし！'
     update: 'アップデート'
     edit: '編集する'
+    destroy: '削除する'
     back: 'もどる'
     message:
       require_login: "ログインしてください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   get 'auth/failure', to: redirect('/')
   delete 'log_out', to: 'sessions#destroy', as: 'log_out'
 
-  resources :teams
+  resources :teams do
+    resource :attendance, only: %i[create destroy], module: :teams
+  end
+
   resources :sessions, only: %i[create destroy]
   resource :profile, only: %i[show edit update]
   

--- a/db/migrate/20240107150640_create_team_attendances.rb
+++ b/db/migrate/20240107150640_create_team_attendances.rb
@@ -1,0 +1,10 @@
+class CreateTeamAttendances < ActiveRecord::Migration[7.0]
+  def change
+    create_table :team_attendances do |t|
+      t.references :team, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_06_145230) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_07_150640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "team_attendances", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_team_attendances_on_team_id"
+    t.index ["user_id"], name: "index_team_attendances_on_user_id"
+  end
 
   create_table "teams", force: :cascade do |t|
     t.integer "target_time", null: false
@@ -41,5 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_06_145230) do
     t.string "provider"
   end
 
+  add_foreign_key "team_attendances", "teams"
+  add_foreign_key "team_attendances", "users"
   add_foreign_key "teams", "users"
 end

--- a/test/controllers/teams/attendances_controller_test.rb
+++ b/test/controllers/teams/attendances_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Teams::AttendancesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/teams/attendance_decorator_test.rb
+++ b/test/decorators/teams/attendance_decorator_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class Teams::AttendanceDecoratorTest < Draper::TestCase
+end

--- a/test/fixtures/team_attendances.yml
+++ b/test/fixtures/team_attendances.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  team: one
+  user: one
+
+two:
+  team: two
+  user: two

--- a/test/models/team_attendance_test.rb
+++ b/test/models/team_attendance_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TeamAttendanceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- チーム参加機能を実装
  - team_attendancesテーブルを追加
  - userとteamに関連付けし、team配下コントローラーを作成
- 懸念点
  - 他のユーザーを作ることができていないため参加できるかどうか検証できていない
  - 定員による募集ステータスの変更を確認できていない