### PR TITLE
Member page fix

### DIFF
--- a/app/controllers/break_times_controller.rb
+++ b/app/controllers/break_times_controller.rb
@@ -1,4 +1,6 @@
 class BreakTimesController < ApplicationController
+  before_action :set_team
+  
   # POST /break_times/pause
   def create 
     # 現在のタイマーを取得または適切なタイマーを特定する
@@ -22,5 +24,11 @@ class BreakTimesController < ApplicationController
     else
       render json: @break_time.errors, status: :unprocessable_entity
     end
+  end
+
+  private
+      
+  def set_team
+    @team = current_user.teams.find(params[:team_id])
   end
 end

--- a/app/controllers/break_times_controller.rb
+++ b/app/controllers/break_times_controller.rb
@@ -1,11 +1,8 @@
 class BreakTimesController < ApplicationController
-  before_action :set_team
+  before_action :set_team, :set_timer
   
   # POST /break_times/pause
   def create 
-    # 現在のタイマーを取得または適切なタイマーを特定する
-    @timer = @team.timers.last
-
     # current_timerがnilでないことを確認
     unless @timer 
       render json: { error: "タイマーが開始されていません" }, status: :unprocessable_entity
@@ -13,12 +10,14 @@ class BreakTimesController < ApplicationController
     end
 
     @break_time = @timer.break_times.create(break_start_time: Time.current, user: current_user)
-    render json: @break_time, status: :ok
+    if @break_time.persisted?
+      render json: { break_time: @break_time, breakTimeId: @break_time.id }, status: :ok
+    end
   end
   
     # POST /break_times/resume
-  def update 
-    @break_time = @team.break_times.last
+  def update
+    @break_time = @timer.break_times.last
     if @break_time.update(break_end_time: Time.current, user: current_user)
       render json: @break_time, status: :ok
     else
@@ -30,5 +29,10 @@ class BreakTimesController < ApplicationController
       
   def set_team
     @team = current_user.teams.find(params[:team_id])
+  end
+
+  # 現在のタイマーを取得または適切なタイマーを特定する
+  def set_timer
+    @timer = @team.timers.last
   end
 end

--- a/app/controllers/break_times_controller.rb
+++ b/app/controllers/break_times_controller.rb
@@ -2,7 +2,7 @@ class BreakTimesController < ApplicationController
   # POST /break_times/pause
   def create 
     # 現在のタイマーを取得または適切なタイマーを特定する
-    current_timer = current_user.timers.last
+    current_timer = @team.timers.last
 
     # current_timerがnilでないことを確認
     unless current_timer
@@ -16,7 +16,7 @@ class BreakTimesController < ApplicationController
   
     # POST /break_times/resume
   def update 
-    @break_time = current_user.break_times.last
+    @break_time = @team.break_times.last
     if @break_time.update(break_end_time: Time.current)
       render json: @break_time, status: :ok
     else

--- a/app/controllers/break_times_controller.rb
+++ b/app/controllers/break_times_controller.rb
@@ -4,22 +4,22 @@ class BreakTimesController < ApplicationController
   # POST /break_times/pause
   def create 
     # 現在のタイマーを取得または適切なタイマーを特定する
-    current_timer = @team.timers.last
+    @timer = @team.timers.last
 
     # current_timerがnilでないことを確認
-    unless current_timer
+    unless @timer 
       render json: { error: "タイマーが開始されていません" }, status: :unprocessable_entity
       return
     end
 
-    @break_time = current_timer.break_times.create(break_start_time: Time.current, user: current_user)
+    @break_time = @timer.break_times.create(break_start_time: Time.current, user: current_user)
     render json: @break_time, status: :ok
   end
   
     # POST /break_times/resume
   def update 
     @break_time = @team.break_times.last
-    if @break_time.update(break_end_time: Time.current)
+    if @break_time.update(break_end_time: Time.current, user: current_user)
       render json: @break_time, status: :ok
     else
       render json: @break_time.errors, status: :unprocessable_entity

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -46,10 +46,12 @@ class TeamsController < ApplicationController
   
   def member_page
     @team = Team.find(params[:id])
-    unless current_user.attend?(@team)
+    @is_activity_period = @team.start_date <= Time.current && Time.current <= @team.end_date
+    unless current_user.attend?(@team) && @is_activity_period
       redirect_to root_path, alert: 'まだチームに参加していないようですね？チームに参加しましょう！'
     end
-      @is_activity_period = @team.start_date <= Time.current && Time.current <= @team.end_date
+    @active_team = current_user.attend_teams.where('start_date <= ? AND end_date >= ?', Time.current, Time.current).order(:end_date).last
+    @previous_team = current_user.attend_teams.where('end_date < ?', Time.current).order(:end_date).last unless @active_team.present?
   end 
   
   private

--- a/app/controllers/timers_controller.rb
+++ b/app/controllers/timers_controller.rb
@@ -1,17 +1,19 @@
 class TimersController < ApplicationController
   
-  def new ;end
+  def new
+    @timer = Timer.new
+  end
 
     # POST /timers/start
-  def create 
-    @timer = current_user.timers.create(start_time: Time.current)
+  def create
+    @timer = @team.timers.create(timer_params.merge(user: current_user, start_time: Time.current))
     render json: @timer, status: :ok
   end
 
   # POST /timers/stop
   def update 
-    @timer = current_user.timers.last
-    if @timer.update(end_time: Time.current)
+    @timer = @team.timers.last
+    if @timer.update(user: current_user, end_time: Time.current)
     render json: { timer: @timer, calculated_time: @timer.calculated_time }, status: :ok     
     else
       render json: @timer.errors, status: :unprocessable_entity

--- a/app/controllers/timers_controller.rb
+++ b/app/controllers/timers_controller.rb
@@ -15,7 +15,7 @@ class TimersController < ApplicationController
   def update 
     @timer = @team.timers.last
     if @timer.update(user: current_user, end_time: Time.current)
-    render json: { timer: @timer, calculated_time: @timer.calculated_time }, status: :ok     
+      render json: { timer: @timer, calculated_time: @timer.calculated_time }, status: :ok     
     else
       render json: @timer.errors, status: :unprocessable_entity
     end

--- a/app/controllers/timers_controller.rb
+++ b/app/controllers/timers_controller.rb
@@ -8,7 +8,11 @@ class TimersController < ApplicationController
     # POST /timers/start
   def create
     @timer = @team.timers.create(user: current_user, start_time: Time.current)
-    render json: @timer, status: :ok
+    if @timer.persisted?
+      render json: { timer: @timer, timerId: @timer.id }, status: :ok
+    else
+      render json: { errors: @timer.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   # POST /timers/stop

--- a/app/controllers/timers_controller.rb
+++ b/app/controllers/timers_controller.rb
@@ -1,4 +1,5 @@
 class TimersController < ApplicationController
+  before_action :set_team
   
   def new
     @timer = Timer.new
@@ -6,7 +7,7 @@ class TimersController < ApplicationController
 
     # POST /timers/start
   def create
-    @timer = @team.timers.create(timer_params.merge(user: current_user, start_time: Time.current))
+    @timer = @team.timers.create(user: current_user, start_time: Time.current)
     render json: @timer, status: :ok
   end
 
@@ -18,5 +19,11 @@ class TimersController < ApplicationController
     else
       render json: @timer.errors, status: :unprocessable_entity
     end
+  end
+
+  private
+  
+  def set_team
+    @team = current_user.teams.find(params[:team_id])
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -4,7 +4,7 @@ class TopsController < ApplicationController
   def index
     # 最後に参加したチームを取得するロジック
     if logged_in?
-      @active_team = current_user.attend_teams.where('end_date >= ?', Time.current).order(:end_date).last
+      @active_team = current_user.attend_teams.where('start_date <= ? AND end_date >= ?', Time.current, Time.current).order(:end_date).last
       @previous_team = current_user.attend_teams.where('end_date < ?', Time.current).order(:end_date).last unless @active_team.present?
     end
   end

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -88,7 +88,7 @@ export default class extends Controller {
   if (this.isPaused) {
     // タイマーが一時停止されていた場合、再開する
     // サーバーに再開時刻を送信(break_end_timeを更新)
-    fetch(`/teams/${this.teamIdValue}timers/${this.timerIdValue}/break_times/${this.breakTimeIdValue}`, { 
+    fetch(`/teams/${this.teamIdValue}/timers/${this.timerIdValue}/break_times/${this.breakTimeIdValue}`, { 
       method: 'PATCH',
       credentials: 'same-origin',
       headers: {
@@ -173,7 +173,6 @@ export default class extends Controller {
         const hours = Math.floor(duration / 3600);
         const minutes = Math.floor((duration % 3600) / 60);
         this.modalTimeTarget.textContent = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-        //this.modalOpen(e);
       })
       .catch(error => {
         console.error('エラー:', error);
@@ -195,7 +194,11 @@ export default class extends Controller {
 
   modalOpen(e) {
     console.log(e)
-    if (this.preventDefaultActionOpening) {
+    if (!this.timerStarted) {
+    // タイマーが開始されていない場合、モーダルを開かない
+    return;
+    }
+    else if (this.preventDefaultActionOpening) {
       e.preventDefault()
     }
 

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -67,8 +67,8 @@ export default class extends Controller {
         }
       })
       .then(data => {
-        // タイマー開始
-        this._startTimer();
+        this.timerIdValue = data.timerId; // 取得したタイマーIDを保存
+        this._startTimer(); // タイマー開始
         this.timerStarted = true; // タイマーが開始されたことを追跡   
         this.isPaused = false;
         this.flashMessageTarget.classList.add('hidden');
@@ -81,7 +81,7 @@ export default class extends Controller {
   togglePauseResume() {
     console.log("Toggle pause/resume called. Current state: ", this.isPaused);
     // タイマーが開始されていない場合、フラッシュメッセージを表示して処理を終了する
-  if (!this.timerStarted) {
+  if (!this.timerStarted || !this.timerIdValue) {
     this.showFlashMessage("スタートが押されていません！");
     return;
   }
@@ -116,7 +116,7 @@ export default class extends Controller {
   } else {
     // タイマーが動作していた場合、一時停止する
     // サーバーに一時停止時刻を送信(break_start_timeの作成)
-    fetch(`/teams/${this.teamIdValue}/timers/${this.timerIdVaule}/break_times`, { 
+    fetch(`/teams/${this.teamIdValue}/timers/${this.timerIdValue}/break_times`, { 
       method: 'POST',
       credentials: 'same-origin',
       headers: {
@@ -133,6 +133,7 @@ export default class extends Controller {
       })
       .then(data => {
         console.log("Fetched response: ", data);
+        this.breakTimeIdValue = data.breakTimeId; // 取得したブレイクタイムIDを保存
         clearInterval(this.timerInterval);
         this.timerInterval = null;
         this.pauseResumeButtonTarget.textContent = 'Resume';

--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["hours", "minutes", "pauseResumeButton", "modalTime", "flashMessage", "modal"]
-  static values = { timerId: Number, breakTimeId: Number}
+  static values = { teamId: Number, timerId: Number, breakTimeId: Number}
   timerStarted = false;
   
   initialize() {
@@ -15,6 +15,7 @@ export default class extends Controller {
   connect(){
     console.log(this.timerIdValue); //タイマーID
     console.log(this.breakTimeIdValue);
+    console.log(this.teamIdValue);
         // The class we should toggle on the container
     this.toggleClass = this.data.get('class') || 'hidden'
     console.log("toggleClass:", this.toggleClass);
@@ -50,7 +51,7 @@ export default class extends Controller {
   start() {
     if (this.timerInterval) return; //すでにタイマーが起動していたら何もしない
     // サーバーにスタート時刻を送信
-    fetch('/timers', { 
+    fetch(`/teams/${this.teamIdValue}/timers`, { 
       method: 'POST',
       credentials: 'same-origin',
       headers: {
@@ -87,7 +88,7 @@ export default class extends Controller {
   if (this.isPaused) {
     // タイマーが一時停止されていた場合、再開する
     // サーバーに再開時刻を送信(break_end_timeを更新)
-    fetch(`/timers/${this.timerIdValue}/break_times/${this.breakTimeIdValue}`, { 
+    fetch(`/teams/${this.teamIdValue}timers/${this.timerIdValue}/break_times/${this.breakTimeIdValue}`, { 
       method: 'PATCH',
       credentials: 'same-origin',
       headers: {
@@ -115,7 +116,7 @@ export default class extends Controller {
   } else {
     // タイマーが動作していた場合、一時停止する
     // サーバーに一時停止時刻を送信(break_start_timeの作成)
-    fetch(`/timers/${this.timerIdVaule}/break_times`, { 
+    fetch(`/teams/${this.teamIdValue}/timers/${this.timerIdVaule}/break_times`, { 
       method: 'POST',
       credentials: 'same-origin',
       headers: {
@@ -149,7 +150,7 @@ export default class extends Controller {
       clearInterval(this.timerInterval);
       this.timerInterval = null;
       // サーバーに終了時刻を送信(end_timeを更新)
-      fetch(`/timers/${this.timerIdValue}`, { 
+      fetch(`/teams/${this.teamIdValue}/timers/${this.timerIdValue}`, { 
         method: 'PATCH',
         credentials: 'same-origin',
         headers: {

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,7 +16,8 @@ class Team < ApplicationRecord
   belongs_to :user
   has_many :team_attendances, dependent: :destroy, class_name: 'TeamAttendance'
   has_many :attendees, through: :team_attendances, class_name: 'User', source: :user
-
+  has_many :timers
+  
   enum status: { wanted: 0, full: 1, finished: 2 }
   
   # ステータスのメソッド
@@ -46,10 +47,7 @@ class Team < ApplicationRecord
 
   # チームの合計学習時間数のメソッド
   def total_calculated_time
-    attendees.includes(:timers).inject(0) do |sum, attendee|
-      attendee_timers_sum = attendee.timers.inject(0) { |attendee_sum, timer| attendee_sum + timer.calculated_time }
-      sum + attendee_timers_sum
-    end
+    timers.sum(&:calculated_time)
   end
 
   # チーム学習目標時間残数

--- a/app/models/timer.rb
+++ b/app/models/timer.rb
@@ -1,5 +1,6 @@
 class Timer < ApplicationRecord
   belongs_to :user
+  belongs_to :team
   has_many :break_times, dependent: :destroy
   
   def calculated_time

--- a/app/views/teams/_team_details.html.erb
+++ b/app/views/teams/_team_details.html.erb
@@ -1,13 +1,14 @@
 <div class="grid grid-cols-6 gap-4">
   <div class="container col-start-2 col-span-4">
     <p class="text-left text-xl">みんなで</p>
-    <h1 class="text-center text-7xl"><%= format_duration(@team.total_calculated_time) %></h1>
+    <h1 class="text-center text-7xl"><%= format_duration(team.total_calculated_time) %></h1>
     <p class="text-center text-lg">時間 分</p>
     <p class="text-right text-xl">森林を増やせました</p>
   </div>
   <div class="container col-start-2 col-span-4">
     <p class="text-left text-xl">絶滅から守るためにあと</p>
-    <h1 class="text-center text-7xl"><%= format_duration(@team.remaining_time) %></h1>
+    <h1 class="text-center text-7xl"><%= format_duration(team.remaining_time) %></h1>
+    <p class="text-center text-lg">時間 分</p>
     <p class="text-right text-xl">森林が必要です</p>
   </div>
 </div>

--- a/app/views/teams/member_page.html.erb
+++ b/app/views/teams/member_page.html.erb
@@ -2,15 +2,11 @@
   <% if @active_team.present? %>
     <!-- 現在活動中のチーム情報を表示 -->
     <%= render 'teams/team_details', team: @active_team %>
-  <% end %>
 
-  <% if @previous_team.present? %>
-    <!-- 最後に参加したチームの結果を表示 -->
-    <%= render 'teams/team_details', team: @previous_team %>
   <% end %>
   <div class="flex flex-col justify-center">
     <% if @is_activity_period %>
-      <%= button_to "学習時間の計測をはじめる", new_timer_path, method: :get, class: 'btn btn-primary' %>
+      <%= button_to "学習時間の計測をはじめる", new_team_timer_path(@team), method: :get, class: 'btn btn-primary' %>
     <% else %>
       <p>活動期間が終了しました</p>
       <%= button_to "新しい仲間を見つける", teams_path, method: :get, class: 'btn btn-primary' %>

--- a/app/views/timers/new.html.erb
+++ b/app/views/timers/new.html.erb
@@ -1,43 +1,38 @@
 <div data-controller="timer" 
-    <% if @timer.present? %>
-      data-timer-timer-id-value="<%= @timer.id %>"
-    <% end %>
-    <% if @break_time.present? %> 
-      data-timer-break_time-id-value="<%= @break_time.id %>"
-    <% end %>>
-      <%= render partial: 'timers/modal' %>
-      <div data-timer-target="flashMessage" role="alert" class="hidden alert"></div>
+     data-timer-team-id-value="<%= @team.id %>" 
+     data-timer-timer-id-value="<%= @timer_id %>" 
+     data-timer-break-time-id-value="<%= @break_time_id %>">
+  <%= render partial: 'timers/modal' %>
+  <div data-timer-target="flashMessage" role="alert" class="hidden alert"></div>
  
-      <div class="flex justify-center items-center min-h-screen bg-gray-100">
-        <div class="text-center">
-          <div class="grid grid-flow-col gap-5 text-center auto-cols-max">
-            <div class="flex flex-col">
-              <span class="font-mono text-5xl">
-                <span data-timer-target="hours">00</span>
-              </span>
-              時間 
-            </div> 
-            <div class="flex flex-col">
-              <span class="font-mono text-5xl">
-                <span data-timer-target="minutes">00</span>
-              </span>
-              分
-            </div>
-          </div>
-          
-          <!-- ストップウォッチのコントロールボタン -->
-          <div class="flex flex-initial">
-            <%= button_tag type: 'button', data: { action: "click->timer#start" }, class: "btn btn-primary mx-2", id: "start-button" do %>
-              Start
-            <% end %>
-            <%= button_tag type: 'button', data: { action: "click->timer#togglePauseResume", timer_target: "pauseResumeButton"}, class: "btn btn-secondary mx-2", id: "pause-resume-button" do %>
-              Pause
-            <% end %>
-            <%= button_tag type: 'button', data: { action: "click->timer#end click->timer#modalOpen" }, class: "btn btn-accent mx-2" do %>
-              End
-            <% end %>
-          </div>
+  <div class="flex justify-center items-center min-h-screen bg-gray-100">
+    <div class="text-center">
+      <div class="grid grid-flow-col gap-5 text-center auto-cols-max">
+        <div class="flex flex-col">
+          <span class="font-mono text-5xl">
+            <span data-timer-target="hours">00</span>
+          </span>
+          時間 
+        </div> 
+        <div class="flex flex-col">
+          <span class="font-mono text-5xl">
+            <span data-timer-target="minutes">00</span>
+          </span>
+          分
         </div>
+      </div>
+          
+      <!-- ストップウォッチのコントロールボタン -->
+      <div class="flex flex-initial">
+        <%= button_tag type: 'button', data: { action: "click->timer#start" }, class: "btn btn-primary mx-2", id: "start-button" do %>
+          Start
+        <% end %>
+        <%= button_tag type: 'button', data: { action: "click->timer#togglePauseResume", timer_target: "pauseResumeButton"}, class: "btn btn-secondary mx-2", id: "pause-resume-button" do %>
+          Pause
+        <% end %>
+        <%= button_tag type: 'button', data: { action: "click->timer#end click->timer#modalOpen" }, class: "btn btn-accent mx-2" do %>
+          End
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/timers/new.html.erb
+++ b/app/views/timers/new.html.erb
@@ -1,7 +1,9 @@
 <div data-controller="timer" 
      data-timer-team-id-value="<%= @team.id %>" 
-     data-timer-timer-id-value="<%= @timer_id %>" 
-     data-timer-break-time-id-value="<%= @break_time_id %>">
+     data-timer-timer-id-value="<%= @timer.id %>" 
+     <% if @break_time.present? %>
+       data-timer-break-time-id-value="<%= @break_time.id %>"
+     <% end %>>
   <%= render partial: 'timers/modal' %>
   <div data-timer-target="flashMessage" role="alert" class="hidden alert"></div>
  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,13 +9,11 @@ Rails.application.routes.draw do
     member do
       get 'member_page'
     end
-  
+    resources :timers, only: %i[new create update] do
+      resources :break_times, only: %i[create update]
+    end
   end
 
-  resources :timers, only: %i[new create update] do
-    resources :break_times, only: %i[create update]
-  end
-  
   resources :sessions, only: %i[create destroy]
   resource :profile, only: %i[show edit update]
   

--- a/db/migrate/20240201013442_add_team_id_to_timers.rb
+++ b/db/migrate/20240201013442_add_team_id_to_timers.rb
@@ -1,0 +1,5 @@
+class AddTeamIdToTimers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :timers, :team, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_26_054732) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_013442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_054732) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "team_id"
+    t.index ["team_id"], name: "index_timers_on_team_id"
     t.index ["user_id"], name: "index_timers_on_user_id"
   end
 
@@ -75,5 +77,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_054732) do
   add_foreign_key "team_attendances", "teams"
   add_foreign_key "team_attendances", "users"
   add_foreign_key "teams", "users"
+  add_foreign_key "timers", "teams"
   add_foreign_key "timers", "users"
 end


### PR DESCRIPTION
メンバーページが活動期間のチームに遷移されるように実装
- timerをteamと関連づけ
- モーダル表示がstartを押さないと出ないように修正

懸念点として、連日で予約している場合即次のチームの表示に変わってしまう可能性がある。
結果を見ることができなくなる。ご意見でたら修正。