### PR TITLE
fix: 活動期間になったら編集できないバリデーション

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -12,6 +12,7 @@ class Team < ApplicationRecord
   validate :valid_end_date
   validate :valid_term
   validate :unique_team_in_same_period, on: %i[create update]
+  validate :editable_within_start_date, on: :update
 
   belongs_to :user
   has_many :team_attendances, dependent: :destroy, class_name: 'TeamAttendance'
@@ -152,5 +153,11 @@ class Team < ApplicationRecord
     self.start_date = start_date.beginning_of_day if start_date.present?
 
     self.end_date = end_date.end_of_day if end_date.present?
+  end
+
+  def editable_within_start_date
+    if start_date <= Time.current
+      errors.add(:base,"編集期限をすぎています。")
+    end
   end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -69,16 +69,18 @@
         </div>
         <% if logged_in? %>
           <% if current_user.own?(@team) %>
-            <div class="card-actions justify-end">
-              <%= link_to "https://twitter.com/intent/tweet?url=#{ request.url }&text=#{@team.title}！森林を増やして一緒に絶滅危惧種を救おう！%0A&hashtags=やる気の森&hashtags=やるもり&hashtags=yarukimorimori",class: "btn btn-primary", target: '_blank' do %>
-                <%= image_tag ("logo-black.png"), size: "20x20" %>シェア！
-              <% end %>
-              <%= button_to t('defaults.edit'), edit_team_path(@team), method: :get, class: 'btn btn-secondary' %>
-              <%= button_to t('defaults.destroy'),
-                            team_path(@team), 
-                            method: :delete, data: { turbo_confirm: '削除しますか？チームメンバーの学習記録も削除されます。' },  
-                            class: 'btn btn-info' %>
-            </div>
+            <% unless @team.start_date <= Time.current %>
+              <div class="card-actions justify-end">
+                <%= link_to "https://twitter.com/intent/tweet?url=#{ request.url }&text=#{@team.title}！森林を増やして一緒に絶滅危惧種を救おう！%0a&hashtags=やる気の森&hashtags=やるもり&hashtags=yarukimorimori",class: "btn btn-primary", target: '_blank' do %>
+                  <%= image_tag ("logo-black.png"), size: "20x20" %>シェア！
+                <% end %>
+                <%= button_to t('defaults.edit'), edit_team_path(@team), method: :get, class: 'btn btn-secondary' %>
+                <%= button_to t('defaults.destroy'),
+                              team_path(@team), 
+                              method: :delete, data: { turbo_confirm: 'ホントに削除しますか？' },  
+                              class: 'btn btn-info' %>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
teamのstart_dateになったら編集ができないようにしました
- モデルにバリデーションを追加
- 詳細ページの編集ボタン、削除ボタンがstart_dateを過ぎたら表示されないように修正