### PR TITLE
Team status full

### DIFF
--- a/app/jobs/adjust_team_state_job.rb
+++ b/app/jobs/adjust_team_state_job.rb
@@ -1,7 +1,8 @@
 class AdjustTeamStateJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    # Do something later
+  def perform(team_id)
+    team = Team.find(team_id)
+    team.update_to_full if team.full?
   end
 end

--- a/app/jobs/adjust_team_state_job.rb
+++ b/app/jobs/adjust_team_state_job.rb
@@ -1,0 +1,7 @@
+class AdjustTeamStateJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,13 +32,18 @@ class Team < ApplicationRecord
     Time.current >= deadline
   end
 
-  def finished_state
-    # デッドラインを過ぎている場合ステータスを更新する
-    return unless deadline?
+  def update_to_full 
+    # statusが:wantedのときのみfullへのステータス変更
+    if full? && status == "wanted"
+      self.status = :full
+      save!
+    end
+  end
 
-    if set_deadline < Time.current
-      new_status = :finished
-      self.status = new_status
+  def update_to_finished
+    # デッドラインを過ぎている場合ステータスを更新する
+    if deadline <= Time.current && (status == "wanted" || status = "full")
+      self.status = :finished
       save!
     end
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,14 +32,15 @@ class Team < ApplicationRecord
     Time.current >= deadline
   end
 
-  def adjust_state
-    # デッドラインを過ぎているか、もしくは定員に達している場合のみステータスを更新する
-    return unless deadline? || full?
+  def finished_state
+    # デッドラインを過ぎている場合ステータスを更新する
+    return unless deadline?
 
-    new_status = deadline? ? :finished : :full
-
-    self.status = new_status
-    save!
+    if set_deadline < Time.current
+      new_status = :finished
+      self.status = new_status
+      save!
+    end
   end
 
   scope :wanted_finished, -> { where('deadline <= ?', Time.current) }

--- a/app/models/team_attendance.rb
+++ b/app/models/team_attendance.rb
@@ -5,6 +5,9 @@ class TeamAttendance < ApplicationRecord
   validates :user_id, uniqueness: { scope: :team_id }
   validate :attendance_restriction
 
+  after_create :enqueue_adjust_team_state
+  after_destroy :enqueue_adjust_team_state
+  
   private
 
   # 同期間のteamには参加できない
@@ -18,5 +21,9 @@ class TeamAttendance < ApplicationRecord
     return unless overlapping_attendance
 
     errors.add(:user_id, 'は同じ期間中に複数のチームに参加できません')
+  end
+
+  def enqueue_adjust_team_state
+    AdjustTeamStateJob.perform_later(team.id)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module StudyingMate
     config.i18n.default_locale = :ja
     config.autoload_paths << Rails.root.join('app/uploaders')
     # Hosts を追加
-    config.hosts << 'yaruki_morimori.onrender.com'
+    config.hosts << 'yaruki-morimori-62d3be1b19e6.herokuapp.com'
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
   config.file_watcher = ActiveSupport::FileUpdateChecker
+  # Active Jobのキューアダプターを:asyncに設定
+  config.active_job.queue_adapter = :async
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,4 +93,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # 開発環境でActive Jobのキューアダプターを:inlineに設定
+  config.active_job.queue_adapter = :inline
 end

--- a/lib/tasks/team_state.rake
+++ b/lib/tasks/team_state.rake
@@ -6,7 +6,7 @@ namespace :team_state do
   end
   task update_team_state: :environment do
     Team.where(status: :wanted).find_each do |team|
-      team.adjust_state
+      team.finished_state
     end
   end
 end

--- a/lib/tasks/team_state.rake
+++ b/lib/tasks/team_state.rake
@@ -6,7 +6,7 @@ namespace :team_state do
   end
   task update_team_state: :environment do
     Team.where(status: :wanted).find_each do |team|
-      team.finished_state
+      team.update_to_finished
     end
   end
 end

--- a/test/jobs/adjust_team_state_job_test.rb
+++ b/test/jobs/adjust_team_state_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AdjustTeamStateJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
teamの参加者が上限に達した時すぐにステータス表示が変わるように変更
- action jobを追加してfullかどうかを判定して非同期で処理するように変更
- fullとfinished(募集期間終了)の判定を分けて定義し、taskではfinishedのみの監視