### PR TITLE
fix: モーダル内容, 編集ボタン

### DIFF
--- a/app/javascript/controllers/timer_controller.js
+++ b/app/javascript/controllers/timer_controller.js
@@ -187,6 +187,10 @@ export default class extends Controller {
         this.shareLinkTarget.setAttribute("href", shareUrl);
         if (data.persisted) {
           console.log("Timer is persisted.");
+        // 既存の編集ボタンを削除
+        const existingEditButtons = document.querySelectorAll("#modal-button .btn-secondary");
+        existingEditButtons.forEach(button => button.remove());
+
           const editButtonHTML = 
             `<a href="/teams/${this.teamIdValue}/timers/${this.timerIdValue}/edit_all_timestamps" class="btn btn-secondary">編集する</a>`;
           document.querySelector("#modal-button").insertAdjacentHTML('beforeend', editButtonHTML);

--- a/app/views/timers/_edit_modal.html.erb
+++ b/app/views/timers/_edit_modal.html.erb
@@ -4,6 +4,15 @@
   style="z-index: 9999;">
   <div class="max-h-screen w-1/2 max-w-2lg relative">
     <div class="bg-white shadow-xl rounded-lg">
+      <div class="flex justify-end">
+        <div class="tooltip tooltip-left"  data-tip="学習計測へ">
+          <%= link_to new_team_timer_path(@team), class: "btn btn-sm btn-circle btn-ghost m-2" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4">
+              <path fill-rule="evenodd" d="M12.5 9.75A2.75 2.75 0 0 0 9.75 7H4.56l2.22 2.22a.75.75 0 1 1-1.06 1.06l-3.5-3.5a.75.75 0 0 1 0-1.06l3.5-3.5a.75.75 0 0 1 1.06 1.06L4.56 5.5h5.19a4.25 4.25 0 0 1 0 8.5h-1a.75.75 0 0 1 0-1.5h1a2.75 2.75 0 0 0 2.75-2.75Z" clip-rule="evenodd" />
+            </svg>
+          <% end %>
+        </div>
+      </div>
       <div class="p-8">
         <h2 class="text-xl mb-4">編集後の学習時間</h2>
         <p class="mb-4"><span data-edit-timer-target="modalTime"></span></p>
@@ -11,7 +20,7 @@
           <%= link_to "#", class: "btn btn-primary mx-2", target: '_blank', data: { edit_timer_target: "shareLink" } do %>
             <%= image_tag ("logo-black.png"), size: "20x20" %> シェア！
           <% end %>
-          <%= link_to "学習計測する", new_team_timer_path(@team), class: "btn btn-secondary m-2" %>
+          <%= link_to "森林を確認", member_page_team_path(@team), class: "btn btn-secondary m-2" %>
           <button class="btn btn-accent mx-2" data-action="click->edit-timer#modalClose">
             編集し直す 
           </button>

--- a/app/views/timers/edit_all_timestamps.html.erb
+++ b/app/views/timers/edit_all_timestamps.html.erb
@@ -6,7 +6,7 @@
     local: false, data: { turbo: false, controller: "edit-timer", target: "edit-timer.form", action: "submit->edit-timer#submitForm" } do |f| %>
     <%= render 'shared/errors_messages', model: f.object %>
     <div data-edit-timer-target="flashMessage" role="alert" class="hidden alert"></div>
-    <div class="mx-12 grid grid-cols-2 gap-6 justify-items-center">      
+    <div class="mx-12 my-12 grid grid-cols-2 gap-6 justify-items-center">      
       <div class="card w-[32rem] bg-base-200 shadow-md p-4">
         <div class="mb-10 field">
           <%= f.label :start_time, t(Timer.human_attribute_name(:start_time)), class: 'label mb-0 text-lg font-semibold text-gray-700' %>


### PR DESCRIPTION
- モーダルのボタンを編集
  - リロードしないと編集ボタンが増えていくようになっていたので毎回ボタンを削除するように変更
  - 編集後のモーダル内のボタンの順番とチームページとタイマーページに行けるように変更