### PR TITLE
fix: 参加中のチームがある場合にバリデーション追加

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -105,11 +105,13 @@ class Team < ApplicationRecord
   end
 
   def unique_team_in_same_period
-    overlapping_teams = Team.where.not(id:).where(user_id:)
+    overlapping_teams = Team.where.not(id: self.id).where(user_id: self.user_id)
                             .where('? < end_date AND start_date < ?', start_date, end_date)
-    return unless overlapping_teams.exists?
-
-    errors.add(:base, '指定された期間内に既に他のチームが存在します。')
+    overlapping_attendance_teams = Team.joins(team_attendances).where.not(id: self.id).where(team_attendances: {user_id: self.user_id})
+                                       .where('? < end_date AND start_date < ?', start_date, end_date)
+    if overlapping_teams.exists? || overlapping_attendance_teams.exists?
+      errors.add(:base, '指定された期間内に既に他のチームが存在します。')
+    end
   end
 
   def create_associated_room


### PR DESCRIPTION
一旦、バリデーションの修正のみ
- teamの作成者ではなく、teamの参加者が新たにteamを作成した場合に、活動期間がかぶっているとエラーが出るように修正。